### PR TITLE
slay the eslint monster

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+{
+  parser: "babel-eslint",
+  "extends": "airbnb",
+  settings: {
+    'import/resolver': {
+      webpack: {}
+    }
+  },
+  "rules": {
+    "react/jsx-filename-extension":"off",
+    "import/extensions": [ 1, "never" ],
+    "react/forbid-prop-types": [ 1, { 'forbid' : [ 'any', 'array' ] } ],
+    "no-unused-vars": [ 1, { argsIgnorePattern: "^_" } ],
+    "max-len": "off",
+    "no-restricted-syntax": ["error", "LabeledStatement", "WithStatement"],
+    "curly": "off"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change history for stripes-form
+
+# 0.7.1 IN PROGRESS
+* Refactoring to make eslint happier. 
+
+## 0.7.0
+* First formal release

--- a/StripesFormModal.js
+++ b/StripesFormModal.js
@@ -1,20 +1,27 @@
-import React, { Component, PropTypes } from 'react';
-import { isDirty } from 'redux-form';
-
+import React from 'react';
+import PropTypes from 'prop-types';
 import Modal from '@folio/stripes-components/lib/Modal';
 import Button from '@folio/stripes-components/lib/Button';
 import css from './StripesFormModal.css';
 
-export default class StripesFormModal extends Component {
-    render() {
-        return (
-            <Modal onClose={this.props.closeCB} size="small" open={this.props.openWhen} label="There are unsaved changes" dismissible>
-                <div className={css.stripesFormModal}>
-                    {this.props.remoteSave && <Button onClick={this.props.saveChanges} fullWidth>Save Changes</Button>}
-                    <Button onClick={this.props.discardChanges} fullWidth>Discard Changes</Button>
-                    <Button onClick={this.props.closeCB} buttonStyle="secondary" fullWidth>Cancel</Button>
-                </div>
-            </Modal>
-        ); 
-    };
+function StripesFormModal(props) {
+  return (
+    <Modal onClose={props.closeCB} size="small" open={props.openWhen} label="There are unsaved changes" dismissible>
+      <div className={css.stripesFormModal}>
+        {props.remoteSave && <Button onClick={props.saveChanges} fullWidth>Save Changes</Button>}
+        <Button onClick={props.discardChanges} fullWidth>Discard Changes</Button>
+        <Button onClick={props.closeCB} buttonStyle="secondary" fullWidth>Cancel</Button>
+      </div>
+    </Modal>
+  );
 }
+
+StripesFormModal.propTypes = {
+  openWhen: PropTypes.bool,
+  saveChanges: PropTypes.func,
+  discardChanges: PropTypes.func,
+  closeCB: PropTypes.func,
+  remoteSave: PropTypes.bool,
+};
+
+export default StripesFormModal;

--- a/StripesFormWrapper.js
+++ b/StripesFormWrapper.js
@@ -1,86 +1,93 @@
-import React, { Component, PropTypes } from 'react';
-import { isDirty } from 'redux-form';
-
-import { withRouter } from 'react-router'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
-
 import StripesFormModal from './StripesFormModal';
 
 class StripesFormWrapper extends Component {
+  constructor(props) {
+    super(props);
 
-    constructor(props) {
-        super(props); 
-
-        this.state = {
-            openModal: false,
-            isBlocking: false,
-            nextLocation: null
-        }
-
-        this.saveChanges = this.saveChanges.bind(this);
-        this.continue = this.continue.bind(this);
-        this.closeModal = this.closeModal.bind(this);
-
-    }
-
-    componentDidMount() {
-        if(this.props.formOptions.navigationCheck) {
-            this.unblock = this.props.history.block((nextLocation)=>{
-                if(this.props.dirty) {
-                    this.setState({
-                        openModal: true,
-                        nextLocation: nextLocation
-                    });
-                }
-                return !this.props.dirty;
-            });
-        }
-    }
-
-    componentWillUnmount(...args) {
-        if(this.props.formOptions.navigationCheck) {
-            this.unblock();
-        }
-    }
-
-    saveChanges() {
-        
-        this.props.dispatch(submit(this.props.formOptions.form));
-
-        if(this.props.invalid) {
-            this.closeModal();
-        } else {
-            this.continue();            
-        }
-
-    }
-
-    continue() {
-        this.unblock();
-        this.props.history.push(this.state.nextLocation.pathname);
-    }
-
-    closeModal() {
-        this.setState({
-            openModal: false
-        });
-    }
-
-    render() {  
-        return (
-           <div>
-                <this.props.Form {...this.props } />
-                <StripesFormModal 
-                    openWhen={this.state.openModal} 
-                    saveChanges={this.saveChanges} 
-                    discardChanges={this.continue}
-                    remoteSave={this.props.formOptions.allowRemoteSave}
-                    closeCB={this.closeModal} 
-                />
-            </div>
-        );
+    this.state = {
+      openModal: false,
+      isBlocking: false,
+      nextLocation: null,
     };
 
+    this.saveChanges = this.saveChanges.bind(this);
+    this.continue = this.continue.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  componentDidMount() {
+    if (this.props.formOptions.navigationCheck) {
+      this.unblock = this.props.history.block((nextLocation) => {
+        if (this.props.dirty) {
+          this.setState({
+            openModal: true,
+            nextLocation,
+          });
+        }
+        return !this.props.dirty;
+      });
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.formOptions.navigationCheck) {
+      this.unblock();
+    }
+  }
+
+  saveChanges() {
+    this.props.dispatch(submit(this.props.formOptions.form));
+
+    if (this.props.invalid) {
+      this.closeModal();
+    } else {
+      this.continue();
+    }
+  }
+
+  continue() {
+    this.unblock();
+    this.props.history.push(this.state.nextLocation.pathname);
+  }
+
+  closeModal() {
+    this.setState({
+      openModal: false,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <this.props.Form {...this.props} />
+        <StripesFormModal
+          openWhen={this.state.openModal}
+          saveChanges={this.saveChanges}
+          discardChanges={this.continue}
+          remoteSave={this.props.formOptions.allowRemoteSave}
+          closeCB={this.closeModal}
+        />
+      </div>
+    );
+  }
 }
+
+StripesFormWrapper.propTypes = {
+  formOptions: PropTypes.shape({
+    allowRemoteSave: PropTypes.bool,
+    navigationCheck: PropTypes.bool,
+  }),
+  history: PropTypes.shape({
+    block: PropTypes.func,
+    push: PropTypes.func,
+  }),
+  dirty: PropTypes.bool,
+  dispatch: PropTypes.func,
+  invalid: PropTypes.bool,
+};
 
 export default withRouter(StripesFormWrapper);

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export {default} from './StripesForm'
+export { default } from './stripesForm';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "docgen": "react-docgen ./lib/ --pretty -e index.js -o ./docs/reactdoc.json ",
-    "lint": "eslint lib || true"
+    "lint": "eslint *.js lib || true"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -23,20 +23,24 @@
     "babel-register": "^6.18.0",
     "eslint": "^3.8.0",
     "eslint-config-airbnb": "^13.0.0",
+    "eslint-import-resolver-webpack": "0.7.1",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.0.1",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.4.1",
-    "eslint-import-resolver-webpack": "0.7.1",
     "webpack": "1.11.0"
   },
   "dependencies": {
+    "@folio/stripes-components": "^1.1.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "moment-range": "^3.0.3",
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
-    "react-overlays": "^0.6.12"
+    "react-overlays": "^0.6.12",
+    "react-router": "^4.1.1",
+    "redux-form": "^6.8.0"
   },
   "peerDependencies": {
     "stripes-core": "^0.5.0"

--- a/stripesForm.js
+++ b/stripesForm.js
@@ -1,21 +1,11 @@
 import React from 'react';
-import {reduxForm} from 'redux-form';
+import { reduxForm } from 'redux-form';
 import { connect } from '@folio/stripes-connect'; // eslint-disable-line
-
-import StripesFormWrapper from "./StripesFormWrapper";
+import StripesFormWrapper from './StripesFormWrapper';
 
 export default function stripesForm(opts) {
-	return function(Form) {
-
-		var StripesForm = React.createClass({
-			render: function() {
-				return (
-					<StripesFormWrapper {...this.props} Form={Form} formOptions={opts} >
-					</StripesFormWrapper>
-				);
-			}
-		});
-
-		return reduxForm(opts)(StripesForm);
-	};
+  return (Form) => {
+    const StripesForm = props => <StripesFormWrapper {...props} Form={Form} formOptions={opts} />;
+    return reduxForm(opts)(StripesForm);
+  };
 }


### PR DESCRIPTION
include own .eslintrc, CHANGELOG.md.
clean up whitespace, commas, and semicolons.
clean up imports and dependencies.
refactor as stateless components.