### PR TITLE
removing unused dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## 0.8.1 In Progress
+* Removing unnecessary dependencies. 
+
 ## [0.8.0](https://github.com/folio-org/stripes-form/tree/v0.8.0) (2017-06-30)
 * Refactoring to make eslint happier. Fixes STRIPES-428. 
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "moment-range": "^3.0.3",
     "prop-types": "^15.5.10",
     "react": "^15.3.2",
-    "react-overlays": "^0.6.12",
     "react-router": "^4.1.1",
     "redux-form": "^6.8.0"
   },


### PR DESCRIPTION
It doesn't appear that `react-overlays` is actually used here. @jeremythuff agreed? If not, can we at least upgrade to `^0.7.0` to help address [STRIPES-311](https://issues.folio.org/browse/STRIPES-311)? 