### PR TITLE
Quickfix: "not saved" prompt wasn't working properly

### DIFF
--- a/StripesFormWrapper.js
+++ b/StripesFormWrapper.js
@@ -85,9 +85,6 @@ StripesFormWrapper.propTypes = {
   history: PropTypes.shape({
     block: PropTypes.func,
     push: PropTypes.func,
-    location: PropTypes.shape({
-      pathname: PropTypes.string,
-    }),
   }),
   dirty: PropTypes.bool,
   dispatch: PropTypes.func,

--- a/StripesFormWrapper.js
+++ b/StripesFormWrapper.js
@@ -21,7 +21,7 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
-        const shouldPrompt = this.props.dirty && !this.props.submitSucceeded && this.props.history.location.pathname !== nextLocation.pathname;
+        const shouldPrompt = this.props.dirty && !this.props.submitSucceeded;
         if (shouldPrompt) {
           this.setState({
             openModal: true,


### PR DESCRIPTION
While working on changes to the StripesFormModal I noticed that the modal wasn't fired when you made changes and clicked on the X to go back. 

This pull request fixes that issue. 

I found that it relates to this issue: https://issues.folio.org/browse/STRIPES-498. The fix should be made in stripes-core -> MainNav instead (I will merge this change).