### PR TITLE
Enable scroll to validation error by default on all the forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ This option will cause Stripes Form to do a dirty check on the form and in a cas
 
 This option will cause the navigation prompt to include a "Save Data" option which will remotely submit the form. This will only result in a persistence of the form data if persistence of the form's data is triggered by a form submission.
 
-    {scrollToError: [true *defaults to false]}
+    {scrollToError: [false *defaults to true]}
 
-This option will cause Stripes Form to scroll to the topmost validation error after submitting a form.
+This option will cause Stripes Form to scroll to the topmost validation error on form submission. Scrolling is enabled by default, and could be turned-off by setting it to false.

--- a/stripesForm.js
+++ b/stripesForm.js
@@ -44,7 +44,9 @@ const optWithOnSubmitFail = opts => Object.assign({
     } else {
       // eslint-disable-next-line no-console
       console.warn(errors);
-      if (opts.scrollToError && errors) scrollToError(errors);
+      if (errors && (typeof opts.scrollToError === 'undefined' || opts.scrollToError === true)) {
+        scrollToError(errors);
+      }
     }
   },
 }, opts);


### PR DESCRIPTION
- The forms scroll to the validation error now by default
- We could pass in an option scrollToError:false in the redux form decorator if we want the scrolling to be disabled