### PR TITLE
Add @folio prefix to stripes-core peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "react": "*",
-    "stripes-core": "^2.7.0"
+    "@folio/stripes-core": "^2.7.0",
+    "react": "*"
   }
 }


### PR DESCRIPTION
Related to https://github.com/folio-org/stripes-components/pull/403

`stripes-core` peer dependency did not have the `@folio` prefix it needs.