### PR TITLE
correct PropTypes for ConfirmationModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.9.0](IN PROGRESS)
 * Added the npm package `flat` to help flatten the nested errors object. Refs STRIPES-467
 * Ignore yarn-error.log file. Refs STRIPES-517. 
+* Correct PropTypes for `<ConfirmationModal>`.
 
 ## [0.8.1](https://github.com/folio-org/stripes-form/tree/v0.8.1) (2017-09-05)
 * Update redux-form dependency to 7.0.3

--- a/StripesFormModal.js
+++ b/StripesFormModal.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { intlShape, FormattedMessage } from 'react-intl';
+import { intlShape } from 'react-intl';
 import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 
 function StripesFormModal(props, context) {
@@ -14,8 +14,8 @@ function StripesFormModal(props, context) {
       heading={unsavedHeading}
       onConfirm={props.remoteSave ? props.saveChanges : props.closeCB}
       onCancel={props.discardChanges}
-      confirmLabel={props.remoteSave ? <FormattedMessage id="stripes-form.saveChanges" /> : <FormattedMessage id="stripes-form.keepEditing" />}
-      cancelLabel={<FormattedMessage id="stripes-form.closeWithoutSaving" />}
+      confirmLabel={props.remoteSave ? context.intl.formatMessage({ id: 'stripes-form.saveChanges' }) : context.intl.formatMessage({ id: 'stripes-form.keepEditing' })}
+      cancelLabel={context.intl.formatMessage({ id: 'stripes-form.closeWithoutSaving' })}
     />
   );
 }


### PR DESCRIPTION
`<ConfirmationModal>` expects its button labels to be strings, not objects.
Make it so.