### PR TITLE
Fix closing unsaved changes. Part of STCOM-306.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [0.9.0](IN PROGRESS)
 * Added the npm package `flat` to help flatten the nested errors object. Refs STRIPES-467
-* Ignore yarn-error.log file. Refs STRIPES-517. 
+* Ignore yarn-error.log file. Refs STRIPES-517.
 * Correct PropTypes for `<ConfirmationModal>`.
+* Fix closing unsaved changes. Part of STCOM-306.
 
 ## [0.8.1](https://github.com/folio-org/stripes-form/tree/v0.8.1) (2017-09-05)
 * Update redux-form dependency to 7.0.3

--- a/StripesFormWrapper.js
+++ b/StripesFormWrapper.js
@@ -51,7 +51,10 @@ class StripesFormWrapper extends Component {
 
   continue() {
     this.unblock();
-    this.props.history.push(this.state.nextLocation.pathname);
+    this.props.history.goBack();
+    setTimeout(() => {
+      this.props.history.push(this.state.nextLocation.pathname);
+    }, 1);
   }
 
   closeModal() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-expermiments/stripes-form",


### PR DESCRIPTION
This is not ideal but it will work with the setup we have in place now.

The `this.props.history.goBack()` will cause the `lastVisited` to be updated for the current module in stripes-core. The `push` will push the next path into a history stack. 