### PR TITLE
Fix injectIntl import

### DIFF
--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
-import { intlShape } from 'react-intl';
+import { injectIntl, intlShape } from 'react-intl';
 import { LastVisitedContext } from '@folio/stripes-core/src/components/LastVisited';
-import { ConfirmationModal, injectIntl } from '@folio/stripes-components';
+import { ConfirmationModal } from '@folio/stripes-components';
 
 class StripesFormWrapper extends Component {
   constructor(props) {


### PR DESCRIPTION
Get `injectIntl` from upstream `react-intl` instead of the `stripes-components` fork.

The `stripes-components` `injectIntl` isn't intended for use outside of components in that repo that need ref forwarding.