### PR TITLE
Change ConfirmationModal import

### DIFF
--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
 import { injectIntl, intlShape } from 'react-intl';
 import { LastVisitedContext } from '@folio/stripes-core/src/components/LastVisited';
-import { ConfirmationModal } from '@folio/stripes-components';
+import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 
 class StripesFormWrapper extends Component {
   constructor(props) {


### PR DESCRIPTION
This is causing:
```
Please refresh the page.
The following occurred resulting in the current page becoming unstable.
ERROR:Object(...) is not a function
    in Switch (created by RootWithIntl)
    in main (created by ModuleContainer)
    in ModuleContainer (created by RootWithIntl)
    in div (created by MainContainer)
    in MainContainer (created by LastVisited)
    in LastVisited (created by Context.Consumer)
    in WithModules(LastVisited) (created by Route)
    in Route (created by withRouter(WithModules(LastVisited)))
    in withRouter(WithModules(LastVisited)) (created by RootWithIntl)
    in Router (created by RootWithIntl)
    in Provider (created by RootWithIntl)
    in FocusTrap (created by HotKeys)
    in HotKeys (created by RootWithIntl)
    in Titled (created by Context.Consumer)
    in GetContext (created by TitleManager)
    in TitleManager (created by RootWithIntl)
    in ModuleTranslator (created by InjectIntl(ModuleTranslator))
    in InjectIntl(ModuleTranslator) (created by RootWithIntl)
    in RootWithIntl (created by Root)
    in IntlProvider (created by Root)
    in ApolloProvider (created by Root)
    in ErrorBoundary (created by Root)
    in Root (created by Context.Consumer)
    in WithModules(Root) (created by Connect(WithModules(Root)))
    in Connect(WithModules(Root))
```

I haven't been able to figure out yet what's special about the ConfirmationModal export, but this change prevents the error.