### PR TITLE
fix package.json repository typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-form
 
+## 1.2.0 (IN PROGRESS)
+
+* Fix typo in `package.json`'s repository value.
+
 ## [1.1.0](https://github.com/folio-org/stripes-form/tree/v1.1.0) (2018-10-02)
 * Move `stripes-core` to dependencies.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
-  "repository": "folio-org/stripes-expermiments/stripes-form",
+  "repository": "folio-org/stripes-form",
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
`package.json`'s repository key should contain a machine-readble URL or
GitHub path where the repository is located. The previous path was out
of date and contained typos. No longer.

Fixes [STFORM-1](https://issues.folio.org/browse/STFORM-1)