### PR TITLE
Replace div in wrapper component with Fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change history for stripes-form
 
-## 1.2.0 (IN PROGRESS)
-
+## [1.1.1](https://github.com/folio-org/stripes-form/tree/v1.1.1) (2018-11-01)
 * Fix typo in `package.json`'s repository value.
+* Replace div in wrapper component with Fragment
 
 ## [1.1.0](https://github.com/folio-org/stripes-form/tree/v1.1.0) (2018-10-02)
 * Move `stripes-core` to dependencies.

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
@@ -71,7 +71,7 @@ class StripesFormWrapper extends Component {
     return (
       <LastVisitedContext.Consumer>
         { ctx => (
-          <div>
+          <Fragment>
             <this.props.Form {...this.props} />
             <ConfirmationModal
               open={openModal}
@@ -86,7 +86,7 @@ class StripesFormWrapper extends Component {
               }
               cancelLabel={intl.formatMessage({ id: 'stripes-form.closeWithoutSaving' })}
             />
-          </div>
+          </Fragment>
         )}
       </LastVisitedContext.Consumer>
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",


### PR DESCRIPTION
## Purpose
`ui-developer` contains a couple instances of `<ConfigForm>` from `stripes-smart-components` where we've had to wrap it in a `<div style={{ width: '100%' }}>`:
https://github.com/folio-org/ui-developer/blob/3ee820976216f0c241a664769685ba977c7d2c46/settings/Token.js#L32

When I tried to remove it, I discovered a rogue `<div>` in there that made using a `<Paneset>` buggy. I traced it here, to the stripes form wrapper component.

## Approach
Replace the `<div>` with a `<Fragment>`.

## Release
Includes `package.json` and `changelog` updates to cut a `v1.1.1` release. Currently blocking https://issues.folio.org/browse/STCOM-387.