### PR TITLE
Replace formatMessage with FormattedMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## 1.2.0 (IN PROGRESS)
+* Replace `formatMessage()` with `<FormattedMessage>`
+
 ## [1.1.1](https://github.com/folio-org/stripes-form/tree/v1.1.1) (2018-11-01)
 * Fix typo in `package.json`'s repository value.
 * Replace div in wrapper component with Fragment

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
-import { injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { LastVisitedContext } from '@folio/stripes-core/src/components/LastVisited';
 import ConfirmationModal from '@folio/stripes-components/lib/ConfirmationModal';
 
@@ -65,7 +65,7 @@ class StripesFormWrapper extends Component {
   }
 
   render() {
-    const { formOptions: { allowRemoteSave }, intl } = this.props;
+    const { formOptions: { allowRemoteSave } } = this.props;
     const { openModal } = this.state;
 
     return (
@@ -75,16 +75,18 @@ class StripesFormWrapper extends Component {
             <this.props.Form {...this.props} />
             <ConfirmationModal
               open={openModal}
-              message={intl.formatMessage({ id: 'stripes-form.unsavedChanges' })}
-              heading={intl.formatMessage({ id: 'stripes-form.areYouSure' })}
+              message={<FormattedMessage id="stripes-form.unsavedChanges" />}
+              heading={<FormattedMessage id="stripes-form.areYouSure" />}
               onConfirm={allowRemoteSave ? this.saveChanges : this.closeModal}
               onCancel={() => this.continue(ctx)}
               confirmLabel={
-                allowRemoteSave ?
-                  intl.formatMessage({ id: 'stripes-form.saveChanges' })
-                  : intl.formatMessage({ id: 'stripes-form.keepEditing' })
+                allowRemoteSave ? (
+                  <FormattedMessage id="stripes-form.saveChanges" />
+                ) : (
+                  <FormattedMessage id="stripes-form.keepEditing" />
+                )
               }
-              cancelLabel={intl.formatMessage({ id: 'stripes-form.closeWithoutSaving' })}
+              cancelLabel={<FormattedMessage id="stripes-form.closeWithoutSaving" />}
             />
           </Fragment>
         )}
@@ -106,9 +108,8 @@ StripesFormWrapper.propTypes = {
     block: PropTypes.func,
     push: PropTypes.func,
   }),
-  intl: intlShape,
   invalid: PropTypes.bool,
   submitSucceeded: PropTypes.bool
 };
 
-export default withRouter(injectIntl(StripesFormWrapper));
+export default withRouter(StripesFormWrapper);


### PR DESCRIPTION
Uses the preferred (and future-friendly) `react-intl` API, `<FormattedMessage>`, since there was no reason to fall back to `intl.formatMessage()` with `injectIntl()`.