### PR TITLE
Revert stripes-core and stripes-components version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## [1.3.1](https://github.com/folio-org/stripes-form/tree/v1.3.1) (2019-01-16)
+* Revert `stripes-core` and `stripes-components` version changes
+
 ## [1.3.0](https://github.com/folio-org/stripes-form/tree/v1.3.0) (2019-01-16)
 * Correctly locate translation files. Fixes STFORM-5.
 * Increment `stripes-core` and `stripes-components` versions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",
@@ -26,8 +26,8 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/stripes-components": "^5.0.1",
-    "@folio/stripes-core": "^3.0.0",
+    "@folio/stripes-components": "^4.0.0",
+    "@folio/stripes-core": "^2.14.0",
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "react-intl": "^2.4.0",


### PR DESCRIPTION
Part of resolution for https://issues.folio.org/browse/FOLIO-1707

`stripes-connect` and `stripes-form` will need major version bumps to prevent newer versions of `stripes-*` dependencies from leaking in.