### PR TITLE
STFORM-6: Handle partially broken `allowRemoteSave` option for the `s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## 2.0.1 IN-PROGRESS
+* Handle partially broken `allowRemoteSave` option for the `stripesForm` function (STFORM-6)
+
 ## [2.0.0](https://github.com/folio-org/stripes-form/tree/v2.0.0) (2019-01-16)
 * Increment `stripes-core` and `stripes-components` versions
 

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -41,13 +41,13 @@ class StripesFormWrapper extends Component {
     }
   }
 
-  saveChanges() {
+  saveChanges(ctx) {
     this.props.dispatch(submit(this.props.formOptions.form));
 
     if (this.props.invalid) {
       this.closeModal();
     } else {
-      this.continue();
+      this.continue(ctx);
     }
   }
 
@@ -64,6 +64,12 @@ class StripesFormWrapper extends Component {
     });
   }
 
+  handleConfirm = (ctx) => {
+    const { formOptions: { allowRemoteSave } } = this.props;
+
+    return allowRemoteSave ? this.saveChanges(ctx) : this.closeModal();
+  };
+
   render() {
     const { formOptions: { allowRemoteSave } } = this.props;
     const { openModal } = this.state;
@@ -77,7 +83,7 @@ class StripesFormWrapper extends Component {
               open={openModal}
               message={<FormattedMessage id="stripes-form.unsavedChanges" />}
               heading={<FormattedMessage id="stripes-form.areYouSure" />}
-              onConfirm={allowRemoteSave ? this.saveChanges : this.closeModal}
+              onConfirm={() => this.handleConfirm(ctx)}
               onCancel={() => this.continue(ctx)}
               confirmLabel={
                 allowRemoteSave ? (


### PR DESCRIPTION
…tripesForm` function