### PR TITLE
Carry over search params. Part of STFORM-7.

### DIFF
--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -23,7 +23,6 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
-        console.log('next location', nextLocation);
         const shouldPrompt = this.props.dirty && !this.props.submitSucceeded;
         if (shouldPrompt) {
           this.setState({

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -23,6 +23,7 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
+        console.log('next location', nextLocation);
         const shouldPrompt = this.props.dirty && !this.props.submitSucceeded;
         if (shouldPrompt) {
           this.setState({
@@ -52,10 +53,16 @@ class StripesFormWrapper extends Component {
   }
 
   continue(ctx) {
+    const {
+      nextLocation: {
+        pathname,
+        search,
+      },
+    } = this.state;
+
     ctx.cachePreviousUrl();
     this.unblock();
-
-    this.props.history.push(this.state.nextLocation.pathname);
+    this.props.history.push(`${pathname}${search}`);
   }
 
   closeModal() {


### PR DESCRIPTION
This PR fixes a bug described in https://issues.folio.org/browse/STFORM-7. 

The location will include search params when navigating away from the form.