### PR TITLE
make stripes dependencies more strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-form
 
-## 2.1.0 (IN-PROGRESS)
+## 2.1.0 IN-PROGRESS
 
 * Handle partially broken `allowRemoteSave` option for the `stripesForm` function (STFORM-6)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-form
 
+## 2.0.1 (IN PROGRESS)
+
+* Make stripes dependencies more strict with ~ instead of ^. Refs STRIPES-608.
+
 ## [2.0.0](https://github.com/folio-org/stripes-form/tree/v2.0.0) (2019-01-16)
 * Increment `stripes-core` and `stripes-components` versions
 

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/stripes-components": "^5.0.1",
-    "@folio/stripes-core": "^3.0.0",
+    "@folio/stripes-components": "~5.0.3",
+    "@folio/stripes-core": "~3.0.4",
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "react-intl": "^2.4.0",


### PR DESCRIPTION
Caret dependencies are too loose in the context of releasing a platform
and allow new minor release to "leak" up into a platform where the
differing versions can cause duplication errors.

Refs [STRIPES-608](https://issues.folio.org/browse/STRIPES-608)