### PR TITLE
upgrade stripes-core, react 16.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-form
 
+## 2.3.0 (IN PROGRESS)
+
+* Increment `stripes-core` to v3.3.0, including React 16.8.
+
 ## [2.2.0](https://github.com/folio-org/stripes-form/tree/v2.2.0) (2019-03-22)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v2.1.0...v2.2.0)
 

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "@folio/eslint-config-stripes": "^3.2.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
-    "react": "^16.5.0",
-    "react-dom": "^16.5.0",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "webpack": "^4.10.2"
   },
   "dependencies": {
     "@folio/stripes-components": "~5.1.0",
-    "@folio/stripes-core": "~3.2.0",
+    "@folio/stripes-core": "~3.3.0",
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "react-intl": "^2.4.0",


### PR DESCRIPTION
Upgrade stripes-core to v3.3.0, providing react 16.8, the one with
hooks.

Refs [STRIPES-599](https://issues.folio.org/browse/STRIPES-599)