### PR TITLE
UICIRC-229 - added missed id for confirmation modal 

### DIFF
--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -86,6 +86,7 @@ class StripesFormWrapper extends Component {
           <Fragment>
             <this.props.Form {...this.props} />
             <ConfirmationModal
+              id="cancel-editing-confirmation"
               open={openModal}
               message={<FormattedMessage id="stripes-form.unsavedChanges" />}
               heading={<FormattedMessage id="stripes-form.areYouSure" />}


### PR DESCRIPTION
# Purpose
To add id attribute for confirmation modal component in order to complete testing in ui-circulation module.