### PR TITLE
Set sideEffects to false to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## 2.3.1 (IN-PROGRESS)
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
+
 ## [2.3.0](https://github.com/folio-org/stripes-form/tree/v2.3.0) (2019-03-28)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v2.2.0...v2.3.0)
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Fullfils STRIPES-564 and STRIPES-581.
- Tested in simple "Hello World" UI app.
- Very small difference since this component is small.

Before:

![Screen Shot 2019-04-23 at 10 33 10 AM](https://user-images.githubusercontent.com/28395235/56591381-a351a180-65b6-11e9-86bc-8c90b78726e4.png)

After:

![Screen Shot 2019-04-23 at 10 53 35 AM](https://user-images.githubusercontent.com/28395235/56591373-9f258400-65b6-11e9-81b2-014bda3d2b3e.png)
