### PR TITLE
STFORM-9 Scroll form to Display Validation Errors that are react elements

### DIFF
--- a/lib/stripesForm.js
+++ b/lib/stripesForm.js
@@ -3,9 +3,11 @@ import { reduxForm, SubmissionError } from 'redux-form';
 import { flatten } from 'flat';
 import StripesFormWrapper from './StripesFormWrapper';
 
+const REACT_ELEMENT_ENDING = /\.\$\$typeof$/;
+
 //  function to scroll to the topmost validation error on a form submit
 const scrollToError = (errors) => {
-  const errorElements = flatten(errors);
+  let errorElements = flatten(errors);
 
   //  function to replace error names of type 'addresses.0.addressType' to 'addresses[0].addressType'
   function replacer(match, p1, p2) {
@@ -19,6 +21,16 @@ const scrollToError = (errors) => {
       delete errorElements[key];
     }
   });
+
+  // add correct paths for react elements
+  errorElements = Object.keys(errorElements).reduce((acc, key) => {
+    const value = errorElements[key];
+
+    acc[key] = value;
+    if (key.match(REACT_ELEMENT_ENDING)) acc[key.replace(REACT_ELEMENT_ENDING, '')] = value;
+
+    return acc;
+  }, {});
 
   const topMostErrorElement = Object.keys(errorElements).reduce((topMostelement, currentElement) => {
     const topMostelementSelector = document.querySelector(`[name="${topMostelement}"]`);


### PR DESCRIPTION
https://issues.folio.org/browse/STFORM-9

problem:
core component doesn't support translated error messages

approach:
detect `$$typeof` property and add its parent property to the errors list