### PR TITLE
bump stripes deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-form
 
+## 2.7.0 (IN PROGRESS)
+
+* Increment `stripes-core` to v3.7.0.
+* Increment `stripes-components` to v5.5.0.
+
 ## [2.6.0](https://github.com/folio-org/stripes-form/tree/v2.6.0) (2019-06-07)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v2.5.0...v2.6.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",
@@ -27,8 +27,8 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/stripes-components": "~5.4.0",
-    "@folio/stripes-core": "~3.6.0",
+    "@folio/stripes-components": "~5.5.0",
+    "@folio/stripes-core": "~3.7.0",
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "react-intl": "^2.4.0",


### PR DESCRIPTION
New features in stripes dependencies mean we need to bump the minor
versions of everything in the stripes dependency chain.