### PR TITLE
STCOM-581 update react-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-form
 
+## 2.10.0 (IN PROGRESS)
+
+* Move react-router to a peerDependency. Refs STCOM-581.
+
 ## [2.9.0](https://github.com/folio-org/stripes-form/tree/v2.9.0) (2019-09-09)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v2.8.0...v2.9.0)
 

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "react-intl": "^2.4.0",
-    "react-router": "^4.1.1",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-router": "^5.0.1"
   }
 }


### PR DESCRIPTION
Update `react-router` to v5 and move it from dependencies to
peerDependencies in order to guarantee that all modules in a
platform are on the same version.

Refs [STCOM-581](https://issues.folio.org/browse/STCOM-581)