### PR TITLE
STFORM-13 move inter-stripes deps to peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.0 (IN PROGRESS)
 
 * Increment `react-router` to `^5.2`. Refs STRIPES-674.
+* Move inter-stripes deps to peers. Refs STFORM-13.
 
 ## [4.0.1](https://github.com/folio-org/stripes-form/tree/v4.0.1) (2020-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v4.0.0...v4.0.1)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.2.1",
     "react": "^16.8.6",
@@ -27,13 +29,13 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@folio/stripes-components": "~8.0.0",
-    "@folio/stripes-core": "~6.0.0",
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "react": "*",
     "react-intl": "^4.5.3",
     "react-router": "^5.2.0"


### PR DESCRIPTION
Inter-stripes deps should be peers, satisfied as direct-deps only by
`@folio/stripes` itself, to make publishing of minor releases easier
without the risk of introducing multiple copies of a library into the
build.

Refs [STFORM-13](https://issues.folio.org/browse/STFORM-13)