### PR TITLE
STFORM-14 update react-intl to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 5.1.0 IN PROGRESS
 
+* Increment `react-intl` to `^5.7`. Refs STFORM-14.
+
 ## [5.0.0](https://github.com/folio-org/stripes-form/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v4.0.1...v5.0.0)
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@folio/stripes-components": "^8.0.0",
     "@folio/stripes-core": "^6.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router": "^5.2.0"
   }
 }


### PR DESCRIPTION
Upgrade `react-intl` to `v5.7` as part of the `@folio/stripes` `v5`
update.

Refs [STFORM-14](https://issues.folio.org/browse/STFORM-14)