### PR TITLE
STFORM-16: Do not show prompt when submitting is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.0 IN PROGRESS
 
 * Increment `react-intl` to `^5.7`. Refs STFORM-14.
+* Do not show prompt when submitting is in progress. Fixes STFORM-16.
 
 ## [5.0.0](https://github.com/folio-org/stripes-form/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v4.0.1...v5.0.0)

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -23,7 +23,9 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
-        const shouldPrompt = this.props.dirty && !this.props.submitSucceeded;
+        const { dirty, submitSucceeded, submitting } = this.props;
+        const shouldPrompt = dirty && !submitSucceeded && !submitting;
+
         if (shouldPrompt) {
           this.setState({
             openModal: true,


### PR DESCRIPTION
https://issues.folio.org/browse/STFORM-16

Do not show prompt when submitting is in progress.

This issue started appearing after the change made in: 

https://issues.folio.org/browse/STSMACOM-460
https://github.com/folio-org/stripes-smart-components/pull/959

Most modules use stripes-final-form where the same check handles it correctly:

https://github.com/folio-org/stripes-final-form/blob/master/lib/StripesFinalFormWrapper.js#L37

ui-requests is still using stripes-form so we need to address it here.



