### PR TITLE
STRIPES-721: Upgrade to react-redux 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "eslint": "^6.2.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-redux": "^5.0.7",
+    "react-redux": "^7.2.0",
     "redux": "^4.0.0",
     "webpack": "^4.10.2"
   },
   "dependencies": {
     "flat": "^4.0.0",
     "prop-types": "^15.5.10",
-    "redux-form": "^7.0.3"
+    "redux-form": "^8.3.0"
   },
   "peerDependencies": {
     "@folio/stripes-components": "^8.0.0",


### PR DESCRIPTION
This is part three of the PRs required to upgrade to react-redux 7 in Stripes.

I'm not sure if we'll be able to get CI builds passing in every repo during the process, but if it's possible, it'll probably be with PR merges in this order:

- [ ] [stripes-connect](https://github.com/folio-org/stripes-connect/pull/163)
- [ ] [stripes-core](https://github.com/folio-org/stripes-core/pull/985) and [stripes-components](https://github.com/folio-org/stripes-components/pull/1484)
- [ ] [stripes-smart-components](https://github.com/folio-org/stripes-smart-components/pull/981) and [stripes-form](https://github.com/folio-org/stripes-form/pull/135)
- [ ] [stripes](https://github.com/folio-org/stripes/pull/114)
- [ ] platforms