### PR TITLE
STRIPES-722 Revert "STFORM-18 react 17"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Do not show prompt when submitting is in progress. Fixes STFORM-16.
 * Increment `stripes-core` to v7.0.0.
 * Increment `stripes-components` to v9.0.0.
-* Increment `react` to v17. STFORM-18.
 
 ## [5.0.0](https://github.com/folio-org/stripes-form/tree/v5.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v4.0.1...v5.0.0)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
@@ -24,8 +22,8 @@
     "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.2.1",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-redux": "^7.2.0",
     "redux": "^4.0.0",
     "webpack": "^4.10.2"
@@ -36,8 +34,8 @@
     "redux-form": "^8.3.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^9.0.0",
-    "@folio/stripes-core": "^7.0.0",
+    "@folio/stripes-components": "^8.0.0",
+    "@folio/stripes-core": "^6.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"


### PR DESCRIPTION
Reverts folio-org/stripes-form#136

Crackerjack research by @aditya-matukumalli and @mkuklis suggests [onFocus changes in React 17](https://github.com/facebook/react/issues/19743), which have caused [event handling trouble for others](https://eng.wealthfront.com/2021/01/14/upgrading-to-react-17-how-to-fix-the-issues-and-breaking-changes/), may be causing [our woes](https://issues.folio.org/browse/STCOR-504) too. 

Refs [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)