### PR TITLE
align dev and peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "redux-form": "^8.3.0"
   },
   "peerDependencies": {
-    "@folio/stripes-components": "^8.0.0",
-    "@folio/stripes-core": "^6.0.0",
+    "@folio/stripes-components": "^9.0.0",
+    "@folio/stripes-core": "^7.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "^5.2.0"


### PR DESCRIPTION
The versions of things specified in dev-deps and peer-deps must match.
They didn't. Whoops.

The dev-deps were correct, so there was no effect here except a build-warning, but wrong is wrong is wrong. 