### PR TITLE
STFORM-28 bump flat to avoid security concerns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-form
 
+## 8.0.0 IN PROGRESS
+
+* *BREAKING* bump `stripes-components`, `stripes-core` major versions.
+* Bump `flat` to avoid security concerns. Refs STFORM-28.
+
 ## [7.1.1](https://github.com/folio-org/stripes-form/tree/v7.1.1) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v7.1.0...v7.1.1)
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "flat": "^4.0.0",
+    "flat": "^5.0.2",
     "prop-types": "^15.5.10",
     "redux-form": "^8.3.0"
   },


### PR DESCRIPTION
Bump `flat` to v5 to avoid prototype pollution in v4.

Refs [STFORM-28](https://issues.folio.org/browse/STFORM-28)