### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for stripes-form
 
 ## 8.0.0 IN PROGRESS
-* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+* Upgrade `react-redux` to `v8`. Refs STFORM-30.
 
 ## [7.1.1](https://github.com/folio-org/stripes-form/tree/v7.1.1) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v7.1.0...v7.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-form
 
+## 8.0.0 IN PROGRESS
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+
 ## [7.1.1](https://github.com/folio-org/stripes-form/tree/v7.1.1) (2022-10-13)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v7.1.0...v7.1.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "7.1.1",
+  "version": "8.0.0",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-form",
@@ -27,7 +27,7 @@
     "eslint-import-resolver-webpack": "^0.13.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-redux": "^7.2.0",
+    "react-redux": "^8.0.5",
     "redux": "^4.0.0",
     "webpack": "^4.10.2"
   },


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STFORM-30.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.