### PR TITLE
STFORM-42 always permit navigation to /logout locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 IN PROGRESS
 
+* Ignore the dirty-form prompt when navigating to a logout location. STFORM-42.
+
 ## [9.0.0](https://github.com/folio-org/stripes-form/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v8.0.0...v9.0.0)
 

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -23,6 +23,13 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
+        // STRIPESFF-35 / STFORM-42 require the nav-prompt to be ignored
+        // on logout. consider calling a common function if this ever needs
+        // to be more elaborate; until then, admire this simple WET impl.
+        if (nextLocation.pathname.startsWith('/logout')) {
+          return true;
+        }
+
         const { dirty, submitSucceeded, submitting } = this.props;
         const shouldPrompt = dirty && !submitSucceeded && !submitting;
 


### PR DESCRIPTION
Always permit navigation to a `/logout` location, even if it would normally be prevented due to a dirty form.

Refs [STFORM-42](https://folio-org.atlassian.net/browse/STFORM-42)