### PR TITLE
STFORM-49 update react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 10.0.0 IN PROGRESS
 
 * *BREAKING* Upgrade `@folio/stripes-*` dependencies. Refs STFORM-48.
+* *BREAKING* Upgrade `react-intl` to `^7`. Refs STFORM-49.
 
 ## [9.1.0](https://github.com/folio-org/stripes-form/tree/v9.1.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-form/compare/v9.0.0...v10.0.0)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "docgen": "react-docgen ./lib/ --pretty -e index.js -o ./docs/reactdoc.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-form ./translations/stripes-form/compiled",
+    "formatjs-compile": "stripes translate compile",
     "lint": "eslint .",
     "test": "echo 'Placeholder. No local unit tests currently implemented.'"
   },
@@ -24,7 +24,6 @@
     "@folio/eslint-config-stripes": "^8.0.0",
     "@folio/stripes-components": "^13.0.0",
     "@folio/stripes-core": "^11.0.0",
-    "@formatjs/cli": "^6.1.3",
     "eslint": "^7.32.0",
     "eslint-import-resolver-webpack": "^0.13.2",
     "react": "^18.2.0",
@@ -42,7 +41,7 @@
     "@folio/stripes-components": "^13.0.0",
     "@folio/stripes-core": "^11.0.0",
     "react": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router": "^5.2.0"
   }
 }


### PR DESCRIPTION
* Update react-intl
* Use stripes-cli to compile translations, allowing the `@formatjs/cli` dependency to be removed

Refs [STFORM-49](https://folio-org.atlassian.net/browse/STFORM-49)