### PR TITLE
Merge release branch to main to bump npm-folioci versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-form
 
-## 10.1.0 IN PROGRESS
+## [10.1.0](https://github.com/folio-org/stripes-form/tree/v10.1.0) (2026-04-14)
 
 * Resolve confirmation modal issue when navigating to same URL. Refs STFORM-54.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-form",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Form state management in Stripes.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
npm-folio has v 10.1.0, but npm-folioci does not since the version has yet to have been bumped. This PR takes care of that.