### PR TITLE
STFORM-56 handle nav guard via stripes-core::isGuardable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Supply Personal Data Disclosure form. Refs STFORM-53.
+* Handle unguardable navigation via stripes-core::isGuardable. Refs STFORM-56.
 
 ## [10.1.0](https://github.com/folio-org/stripes-form/tree/v10.1.0) (2026-04-14)
 

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { submit } from 'redux-form';
 import { FormattedMessage } from 'react-intl';
-import { LastVisitedContext } from '@folio/stripes-core';
+import { LastVisitedContext, isGuardable } from '@folio/stripes-core';
 import { ConfirmationModal } from '@folio/stripes-components';
 
 class StripesFormWrapper extends Component {
@@ -23,12 +23,10 @@ class StripesFormWrapper extends Component {
   componentDidMount() {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
-        // STRIPESFF-35 / STFORM-42 require the nav-prompt to be ignored
-        // on logout. consider calling a common function if this ever needs
-        // to be more elaborate; until then, admire this simple WET impl.
-        if (nextLocation.pathname.startsWith('/logout')) {
+        // some nav (e.g. to `/logout` when a session ends) cannot be guarded
+        if (!isGuardable(nextLocation.pathName)) {
           return true;
-        }
+        } 
 
         const { dirty, submitSucceeded, submitting } = this.props;
         const shouldPrompt = dirty && !submitSucceeded && !submitting;

--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -26,7 +26,7 @@ class StripesFormWrapper extends Component {
         // some nav (e.g. to `/logout` when a session ends) cannot be guarded
         if (!isGuardable(nextLocation.pathName)) {
           return true;
-        } 
+        }
 
         const { dirty, submitSucceeded, submitting } = this.props;
         const shouldPrompt = dirty && !submitSucceeded && !submitting;
@@ -90,7 +90,7 @@ class StripesFormWrapper extends Component {
 
     return (
       <LastVisitedContext.Consumer>
-        { ctx => (
+        {ctx => (
           <>
             <this.props.Form {...this.props} />
             <ConfirmationModal


### PR DESCRIPTION
Instead of hard-coding `/logout` as unguardable-navigation, leverage stripes-core's `isGuardable()`.

Refs [STFORM-56](https://folio-org.atlassian.net/browse/STFORM-56), [STRIPES-1026](https://folio-org.atlassian.net/browse/STRIPES-1026)