### PR TITLE
STFORM-57 pass correct arguments to stripes-core::isGuardable

### DIFF
--- a/lib/StripesFormWrapper.js
+++ b/lib/StripesFormWrapper.js
@@ -24,7 +24,7 @@ class StripesFormWrapper extends Component {
     if (this.props.formOptions.navigationCheck) {
       this.unblock = this.props.history.block((nextLocation) => {
         // some nav (e.g. to `/logout` when a session ends) cannot be guarded
-        if (!isGuardable(nextLocation.pathName)) {
+        if (!isGuardable(nextLocation.pathname)) {
           return true;
         }
 


### PR DESCRIPTION
Pass `nextLocation.pathname`. `nextLocation.pathName` is not a thing. Whoops.

Refs [STFORM-57](https://folio-org.atlassian.net/browse/STFORM-57), [STFORM-56](https://folio-org.atlassian.net/browse/STFORM-56)